### PR TITLE
AI-71 bug clashing elements

### DIFF
--- a/RevitClasher/Properties/AssemblyInfo.cs
+++ b/RevitClasher/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("RVT_AutomateClash")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("ENGworks")]
 [assembly: AssemblyProduct("RVT_AutomateClash")]
 [assembly: AssemblyCopyright("Copyright ©  2018")]
 [assembly: AssemblyTrademark("")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/RevitClasher/RevitClasher.csproj
+++ b/RevitClasher/RevitClasher.csproj
@@ -165,10 +165,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>IF EXIST "%25APPDATA%25\Autodesk\Revit\Addins\2018\RevitClasher" rmdir /S /Q "%25APPDATA%25\Autodesk\Revit\Addins\2018\RevitClasher"
-mkdir "%25APPDATA%25\Autodesk\Revit\Addins\2018\RevitClasher"
-xcopy /Y "$(TargetFileName)" "%25APPDATA%25\Autodesk\Revit\Addins\2018\RevitClasher\"
-xcopy /Y "$(TargetDir)\Resources" "%25APPDATA%25\Autodesk\Revit\Addins\2018\RevitClasher\Resources\"
-xcopy /Y "$(ProjectDir)RevitClasher.addin" "%25APPDATA%25\Autodesk\Revit\Addins\2018\"</PostBuildEvent>
+    <PostBuildEvent>IF EXIST "%25APPDATA%25\Autodesk\Revit\Addins\2019\RevitClasher" rmdir /S /Q "%25APPDATA%25\Autodesk\Revit\Addins\2020\RevitClasher"
+mkdir "%25APPDATA%25\Autodesk\Revit\Addins\2019\RevitClasher"
+xcopy /Y "$(TargetFileName)" "%25APPDATA%25\Autodesk\Revit\Addins\2020\RevitClasher\"
+xcopy /Y "$(TargetDir)\Resources" "%25APPDATA%25\Autodesk\Revit\Addins\2020\RevitClasher\Resources\"
+xcopy /Y "$(ProjectDir)RevitClasher.addin" "%25APPDATA%25\Autodesk\Revit\Addins\2020\"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/RevitClasher/Tools.cs
+++ b/RevitClasher/Tools.cs
@@ -168,7 +168,7 @@ namespace RevitClasher
         /// Detects the collision or clash between two elements. By analyzing the geometry intersection of an element (Element A) against other element (Element B)
         /// </summary>
         /// <param name="doc">Active revit document</param>
-        /// <param name="geometryElement">Geometry of the element that will be intersected (Element A)</param>
+        /// <param name="geometryElement">Geometry element from which the intersection will be verified (Element A)</param>
         /// <param name="element">Element to verify the presence of intersection (Element B)</param>
         /// <returns>A Boolean flag that indicates whether or not there is a clash between elements. True = Clash detected. False = No clash detected</returns>
         public static bool getClashWithSolid(Document doc, GeometryElement geometryElement, Element element)


### PR DESCRIPTION
# Clashing FAB elements
This pull request fix a bug encountered when a FAB part is selected to verify a clash to another element in revit project.

<img src="https://user-images.githubusercontent.com/62384430/78830965-d56e3600-79b6-11ea-83cf-dcd544189314.png" alt="image" width="340">

## Problem description
The problem was that, for this specific element (Fabrication parts) their geometry are composed by [mesh objects](https://knowledge.autodesk.com/support/revit-products/learn-explore/caas/CloudHelp/cloudhelp/2014/ENU/Revit/files/GUID-A4E51A50-60EF-4D49-9944-4935FA88CD11-htm.html) (Tiny little triangles that creates a Geometry object). Based on the official Autodesk documentation and [discussion forums](https://forums.autodesk.com/t5/revit-api-forum/fabrication-parts-elementintersection/td-p/9396509) isn't possible to use these elements and their geometries with the `ElementIntersectsSolidFilter` method from Revit API because this filter is incompatible with mesh objects from the FAB part and the solid objects retrived from these parts are empty. This results in null value returned from the `FilteredElementCollector` when the filter applyies the `ElementsIntersectsSolidFilter` and the clash process fails.

## Problem solution
A solution to this problem is use, the `BoundingBoxIntersectsFilter` method from Revit API. The main approach of this method is that we create a bounding box from the geometry of the element that will be intersected and with this Bounding Box filter actually is possible to detect the clash against other elements like walls, generic parts, pillars and beams. This bounding box intersection doesn't have the same precision that a solid intersection, but is faster and fix the problem. 

## Future considerations
Perhaps a better solution is implements a convex hull algorithm using a library, but this will take more time to achieve. 

## Testing considerations
Is necessary to test clash between FAB parts and other elements like walls and vice versa.  The result will be the same clashing elements on the model should be highlighted.

(Example)
<img src="https://user-images.githubusercontent.com/62384430/78833144-62ff5500-79ba-11ea-87df-0d05b5eee6e3.png" alt="image" width="300">
_Notice that the ducts are clashing with the wall and the elements involed in the clash are highlighted in green and red_